### PR TITLE
history を props からも取れるように

### DIFF
--- a/lib/TheDropdownMenu.jsx
+++ b/lib/TheDropdownMenu.jsx
@@ -66,7 +66,7 @@ class TheDropDownMenu extends React.PureComponent {
     const s = this
     const {eventsToClose} = s.props
     const window = get('window')
-    const {history} = s.context
+    const history = s.context.history || s.props.history
     for (const event of eventsToClose) {
       window.addEventListener(event, s.close)
     }


### PR DESCRIPTION
[the-router/withHistory.js](https://github.com/the-labo/the-router/blob/master/lib/withHistory.jsx) では props に history を渡している。 
ので withHistory と組み合わせて使えるようにした。