### PR TITLE
Dropdown Menu の width 指定を 'max-content' にした

### DIFF
--- a/lib/TheMenuStyle.jsx
+++ b/lib/TheMenuStyle.jsx
@@ -147,7 +147,7 @@ TheMenuStyle.data = (options) => {
         overflow: 'hidden',
         position: 'absolute',
         transition: `opacity ${animationDuration}ms, box-shadow ${animationDuration}ms, border-color ${animationDuration}ms`,
-        width: 'auto',
+        width: 'max-content',
         zIndex: 8,
       },
       '.the-menu': {


### PR DESCRIPTION
ドロップダウンメニューのメニューが `width: auto` だと、 常に `min-width` に合わせた幅になっている。そのためわりと短い文字列でも折り返しが発生してしまう。

なので、`width: max-content` にした。

![2018-06-14 16 20 23](https://user-images.githubusercontent.com/16313897/41397341-e002742e-6fee-11e8-95db-548d4f833f59.png)
